### PR TITLE
Use include-with-user

### DIFF
--- a/anarchy/build.sh
+++ b/anarchy/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+ln -s `pwd` $ATBUILD_USER_PATH/AnarchyDispatch
 rm -rf anarchy/module.modulemap
 if [ `uname` == "Darwin" ]; then
     echo "Not building libdispatch on Darwin; using system libdispatch"

--- a/build.atpkg
+++ b/build.atpkg
@@ -2,10 +2,11 @@
 :name "AnarchyDispatch"
     :overlays {
         :compile-osx {
-            :compile-options ["-I" "AnarchyDispatch/anarchy"]
+            :include-with-user ["AnarchyDispatch/anarchy"]
         }
         :compile-linux {
-            :compile-options ["-I" "AnarchyDispatch/anarchy" "-I" "AnarchyDispatch/" "-Xcc" "-fblocks"]
+            :include-with-user ["AnarchyDispatch/anarchy" "AnarchyDispatch/"]
+            :compile-options ["-Xcc" "-fblocks"]
             :link-options ["-LAnarchyDispatch/build/lib/"]
         }
     }


### PR DESCRIPTION
The use of include-with-user is superior to -I in exactly this case
(integration with an external build system).

This is because if AnarchyTools is deeply imported, all packages should
have access to it.